### PR TITLE
카카오 로그인 기능 구현

### DIFF
--- a/login-test/src/App.tsx
+++ b/login-test/src/App.tsx
@@ -1,3 +1,5 @@
+// App.tsx
+
 import Router from "./Router";
 
 function App() {

--- a/login-test/src/Router.tsx
+++ b/login-test/src/Router.tsx
@@ -1,3 +1,5 @@
+// Router.tsx
+
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import KakaoLogin from "./component/KakaoLogin";
 import KakaoCallback from "./component/KakaoCallback";

--- a/login-test/src/component/KakaoCallback.tsx
+++ b/login-test/src/component/KakaoCallback.tsx
@@ -1,3 +1,5 @@
+// KakaoCallback.tsx
+
 import { useEffect } from "react";
 import axios from "axios";
 import { CLIENT_ID, REDIRECT_URI } from "../constant/OAuth";

--- a/login-test/src/component/KakaoLogin.tsx
+++ b/login-test/src/component/KakaoLogin.tsx
@@ -1,3 +1,5 @@
+// KakaoLogin.tsx
+
 import { KAKAO_AUTH_URL } from "../constant/OAuth";
 import loginLogo from "../assets/loginLogo.png";
 
@@ -5,10 +7,7 @@ function KakaoLogin() {
   return (
     <div>
       <a href={KAKAO_AUTH_URL}>
-        <img
-          src={loginLogo}
-          alt="카카오로 계속하기"
-        />
+        <img src={loginLogo} alt="카카오로 계속하기" />
       </a>
     </div>
   );

--- a/login-test/src/constant/OAuth.ts
+++ b/login-test/src/constant/OAuth.ts
@@ -1,3 +1,5 @@
+// OAuth.ts
+
 export const CLIENT_ID = import.meta.env.VITE_APP_REST_API_KEY;
 export const REDIRECT_URI = import.meta.env.VITE_APP_REDIRECT_URI;
 


### PR DESCRIPTION
**💥기능 구현**

- 소셜 로그인 PreTask
    - client ID, redirect url 활용하여 URL 생성 (→ 카카오 이미지 클릭 시, 해당 주소로 이동)
        - `prompt=login` : 기존 사용자 인증 여부와 상관없이, 로그인 화면 출력함
            - 해당 옵션이 없으면 기존 사용자는 인증하지 않고 바로 인가코드 발급됨 (이번엔 테스트를 위해서 설정해줬슴당)
        - 인가코드 활용하여 access_token, refresh_token, 유저 정보 받아오기 성공

대략 요런 느낌으로 구현했습니당!

![image](https://github.com/Arooming/TATTOUR-PreTask/assets/80264647/477c01a5-8bb6-4b1d-b6fe-d8b336e45374)

![image](https://github.com/Arooming/TATTOUR-PreTask/assets/80264647/875eb6d7-d0cc-4107-b308-c1ddd0cb2f81)

![image](https://github.com/Arooming/TATTOUR-PreTask/assets/80264647/ff612feb-d57c-476a-91fe-8e244af07432)


<br />
<hr />

**👀 코멘트**

코드 리뷰를,,,, 망각하고,, main에서 작업한 바람에 pr용 브랜치를 따로 팠습ㄴㅣ다,,,(지송)
코드 영역 늘려서 봐주심 됩니다 ㅎㅎ!!!

보기 불편하겠지만, 가볍게 보시구 편하게 의견 주심 감사하겠슴돠..!

~~브랜치 파기를 잊지말자!~~

<br />
<hr />

**📖 reference**

- https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api
- https://velog.io/@adguy/%EC%B9%B4%EC%B9%B4%EC%98%A4-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84web%EC%9A%B0%EB%A6%AC%EB%82%98%EB%9D%BC%EC%97%90%EC%84%9C-%EA%B0%80%EC%9E%A5-%EC%89%BD%EA%B2%8C-%EC%95%8C%EB%A0%A4%EC%A3%BC%EA%B8%B0React-restAPI-%EB%B0%A9%EC%8B%9D